### PR TITLE
Add CMake support and cover more ground in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,58 @@
-language: c
-script: "cc -ansi -pedantic -Wall -Werror -c json.c"
-branches:
-  only:
-    - master
-notifications:
-  recipients:
-    - jamie@lacewing-project.org
-  email:
-    on_success: change
-    on_failure: always
+language: c++
+sudo: false
 
+matrix:
+  include:
+    - compiler: clang
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-5
+cache:
+  apt: true
+  directories:
+  - "$HOME/.travis/cmake/build/install"
 
+before_install:
+  # make sure we use gcc 5
+  - if [ "$CC"  == "gcc" ]; then export CC=gcc-5; fi
+  - if [ "$CXX" == "g++" ]; then export CXX=g++-5; fi
+  # make sure we use at least CMake 3.1 (cached)
+  - pushd . && cd $HOME
+  - git clone https://github.com/LB--/travis.git travis
+  - source "./travis/update-cmake.sh"
+  - popd
 
+script:
+  # plain compilation
+  - $CC -ansi -pedantic -Wall -Werror -c json.c
+
+  # clean
+  - git add --all && git reset --hard
+
+  # with make
+  - ./configure
+  - make
+
+  # clean
+  - git add --all && git reset --hard
+
+  # with CMake, without source tracking but with install test
+  - mkdir -p build && cd build
+  - cmake .. -DCMAKE_INSTALL_PREFIX="$(pwd)/install"
+  - cmake --build . --target install
+  - ls -R install
+  - ctest -VV
+
+  # clean
+  - cd ..
+  - git add --all && git reset --hard
+
+  # with CMake, with source tracking
+  - mkdir -p build && cd build
+  - cmake .. -DJSON_TRACK_SOURCE=ON
+  - cmake --build .
+  - ctest -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(json-parser)
+
+add_library(json-parser json.c)
+set_property(TARGET json-parser PROPERTY C_STANDARD 99) # or 11
+target_include_directories(json-parser PUBLIC .)
+
+option(JSON_TRACK_SOURCE "Enables source tracking via compile definition")
+if(JSON_TRACK_SOURCE)
+	target_compile_definitions(json-parser PUBLIC JSON_TRACK_SOURCE)
+endif()
+
+# detect if we need libm
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS(pow HasPow)
+if(NOT HasPow)
+	list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+	CHECK_FUNCTION_EXISTS(pow HasPowLibm)
+	if(HasPowLibm)
+		target_link_libraries(json-parser PUBLIC m)
+	else()
+		message(FATAL_ERROR "The C pow() function is required by json-parser")
+	endif()
+endif()
+
+install(FILES json.h DESTINATION include)
+install(TARGETS json-parser ARCHIVE DESTINATION lib)
+
+enable_testing()
+
+option(BUILD_PYTHON_MODULE "Enable experimental support for building the python bindings and running the python tests with CMake")
+if(BUILD_PYTHON_MODULE)
+	find_package(PythonInterp 2 EXACT) # the Python tests and bindings are not compatible with Python 3
+	if(PYTHONINTERP_FOUND)
+		get_filename_component(PYTHON_DIRECTORY ${PYTHON_EXECUTABLE} DIRECTORY)
+
+		add_library(json-python-module SHARED bindings/python/wrap_json.c)
+		set_target_properties(json-python-module PROPERTIES
+			OUTPUT_NAME "jsonparser.pyd"
+			PREFIX ""
+			SUFFIX ""
+			C_STANDARD 99
+		)
+		if(WIN32)
+			target_include_directories(json-python-module PUBLIC "${PYTHON_DIRECTORY}/include")
+			target_link_libraries(json-python-module "${PYTHON_DIRECTORY}/libs/libpython${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.a")
+			if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+				target_compile_definitions(json-python-module PUBLIC MS_WIN64)
+			endif()
+		else()
+			target_include_directories(json-python-module PUBLIC "${PYTHON_DIRECTORY}/../include/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+			target_link_libraries(json-python-module "${PYTHON_DIRECTORY}/../lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.a")
+			if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+				message(WARNING "Linking to libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.a will likely fail unless it is 64-bit or built with -fPIC")
+			endif()
+		endif()
+		add_test(
+			NAME python-tests
+			COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_LIST_DIR}/tests/test.py"
+			WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/tests/"
+		)
+		set_property(
+			TEST python-tests
+			PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}"
+		)
+	endif()
+endif()
+
+if(NOT WIN32) # test_json.c does not work on Windows
+	add_executable(example-c examples/test_json.c)
+	target_link_libraries(example-c json-parser)
+	add_test(
+		NAME example-c-test
+		COMMAND example-c "valid-0000.json"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/tests/"
+	)
+endif()
+
+# Convenience for the possible future
+#add_executable(example-cpp examples/test_json.cpp)
+#set_property(TARGET example-cpp PROPERTY CXX_STANDARD 11) # to test the features conditional on C++11
+#target_link_libraries(example-cpp json-parser)
+#add_test(
+#	NAME example-cpp-test
+#	COMMAND example-cpp "valid-0000.json"
+#	WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/tests/"
+#)

--- a/examples/test_json.c
+++ b/examples/test_json.c
@@ -92,6 +92,9 @@ static void process_value(json_value* value, int depth)
                 case json_none:
                         printf("none\n");
                         break;
+                case json_null:
+                        printf("null\n");
+                        break;
                 case json_object:
                         process_object(value, depth+1);
                         break;
@@ -99,7 +102,7 @@ static void process_value(json_value* value, int depth)
                         process_array(value, depth+1);
                         break;
                 case json_integer:
-                        printf("int: %d\n", value->u.integer);
+                        printf("int: %ld\n", value->u.integer);
                         break;
                 case json_double:
                         printf("double: %f\n", value->u.dbl);
@@ -148,7 +151,7 @@ int main(int argc, char** argv)
                 return 1;
         }
         if ( fread(file_contents, file_size, 1, fp) != 1 ) {
-                fprintf(stderr, "Unable t read content of %s\n", filename);
+                fprintf(stderr, "Unable to read content of %s\n", filename);
                 fclose(fp);
                 free(file_contents);
                 return 1;


### PR DESCRIPTION
I have added CMake support for the people who like CMake (such as myself), and I also modified the Travis script to test a lot more functionality.

If you give cmake `-DJSON_TRACK_SOURCE=ON` then it will properly add the compilation flag for that.

The travis script looks monstrous but I assure you it is as minimal as I could make it considering how outdated Travis' stuff is. The script tests against both clang 3.4 and GCC 5.1. CMake 3.1 is required so that gets built from source and cached by Travis (so it only needs to be built from source the first time). The build script for bootstrapping CMake is cloned in from my own repository of travis-related scripts, but if you don't want that, I can copy the particular script to this repository somewhere. (Travis doesn't currently support `sudo` or arbitrary apt sources, so some stuff can only be built from source and installed locally - unless you want to use the legacy infrastructure which is not well supported)

The Travis script now compiles json-parser in every way I could think of:
* The original way you had it
* With `./configure && make`
* With CMake and default settings + install
* With CMake and `-DJSON_TRACK_SOURCE=ON`

I also spent [several hours](https://travis-ci.org/LB--/json-parser/builds) trying to get the python stuff to work, and I got really close, but the issue is that the libpython2.7.a on Travis' machines is 32bit and built without `-fPIC`, so it's impossible to ever link to it because the compilers are all 64-bit. So for now I just made the python stuff optional and turned off by default. (I also have no idea what I am doing here because I don't use Python)

Regardless of the python stuff, at least I got the `test_json.c` included for non-Windows builds - it gets run by `ctest` in Travis. In the future I also want to add a `test_json.cpp` so that the C++ parts of json-parser can get some testing, but that's too much for me right now.

I ended up fixing some other bugs along the way to getting the python tests to run - if you want me to just revert all that and remove the python stuff from the CMake script, I'd understand.

If you want me to separate out all the travis stuff into a separate pull request, I can do that too - just let me know what you prefer.