### PR TITLE
Silence missing field initializer warnings

### DIFF
--- a/json.c
+++ b/json.c
@@ -227,10 +227,11 @@ json_value * json_parse_ex (json_settings * settings,
    json_char error [json_error_max];
    const json_char * end;
    json_value * top, * root, * alloc = 0;
-   json_state state = { 0, UINT_MAX, ULONG_MAX, *settings, 0, NULL, 0, 0 };
+   json_state state = { 0, UINT_MAX, ULONG_MAX, { 0 }, 0, NULL, 0, 0 };
    long flags;
    long num_digits = 0, num_e = 0;
    json_int_t num_fraction = 0;
+   state.settings = *settings;
 
    /* Skip UTF-8 BOM
     */

--- a/json.c
+++ b/json.c
@@ -41,6 +41,7 @@ const struct _json_value json_value_none;
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <limits.h>
 
 typedef unsigned int json_uchar;
 
@@ -226,7 +227,7 @@ json_value * json_parse_ex (json_settings * settings,
    json_char error [json_error_max];
    const json_char * end;
    json_value * top, * root, * alloc = 0;
-   json_state state = { 0 };
+   json_state state = { 0, UINT_MAX, ULONG_MAX, *settings, 0, NULL, 0, 0 };
    long flags;
    long num_digits = 0, num_e = 0;
    json_int_t num_fraction = 0;
@@ -244,16 +245,11 @@ json_value * json_parse_ex (json_settings * settings,
    error[0] = '\0';
    end = (json + length);
 
-   memcpy (&state.settings, settings, sizeof (json_settings));
-
    if (!state.settings.mem_alloc)
       state.settings.mem_alloc = default_alloc;
 
    if (!state.settings.mem_free)
       state.settings.mem_free = default_free;
-
-   memset (&state.uint_max, 0xFF, sizeof (state.uint_max));
-   memset (&state.ulong_max, 0xFF, sizeof (state.ulong_max));
 
    state.uint_max -= 8; /* limit of how much can be added before next check */
    state.ulong_max -= 8;

--- a/json.c
+++ b/json.c
@@ -944,7 +944,7 @@ e_failed:
 
 json_value * json_parse (const json_char * json, size_t length)
 {
-   json_settings settings = { 0 };
+   json_settings settings = { 0, 0, NULL, NULL, NULL, 0 };
    return json_parse_ex (&settings, json, length, 0);
 }
 
@@ -1000,7 +1000,7 @@ void json_value_free_ex (json_settings * settings, json_value * value)
 
 void json_value_free (json_value * value)
 {
-   json_settings settings = { 0 };
+   json_settings settings = { 0, 0, NULL, NULL, NULL, 0 };
    settings.mem_free = default_free;
    json_value_free_ex (&settings, value);
 }


### PR DESCRIPTION
I'm really glad I found this library; I love the simple design.

When compiling `json-parser` with `-Wall` and `-Wextra` using `clang-700.1.81`, I was getting some `missing-initalizer` warnings. I thought it would be nice to silence those.

I also removed some usages of `memcpy` and `memset` that looked like they could be replaced by direct initialization. I may be missing something there though; if needed, I will update the PR to initialize those fields to zero and restore the separate initialization steps. I ran the test suite and all the tests passed.
